### PR TITLE
Support changeable deployment timeout.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   use_existing_version_if_available:
     description: 'If set to "true" then the action will deploy an existing version with the given version_label if it already exists, but otherwise create the version and deploy it.'
     required: false
+  max_waiting_deploy_time:
+    description: 'If you want to change retry timeout when waiting environment to Green, Default value is 30 seconds'
+    required: false
 branding:
   icon: 'arrow-up'  
   color: 'green'

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -275,6 +275,7 @@ function waitForDeployment(application, environmentName, versionLabel, start) {
     let degraded = false;
     let healThreshold;
     let deploymentFailed = false;
+    let deployWaitingTime = ParseInt(Process.env.INPUT_MAX_WAITING_DEPLOY_TIME || 30);
 
     const SECOND = 1000;
     const MINUTE = 60 * SECOND;
@@ -323,7 +324,7 @@ function waitForDeployment(application, environmentName, versionLabel, start) {
                         } else {
                             console.warn(`Environment update finished, but health is ${env.Health} and health status is ${env.HealthStatus}. Giving it 30 seconds to recover...`);
                             degraded = true;
-                            healThreshold = new Date(new Date().getTime() + 30 * SECOND);
+                            healThreshold = new Date(new Date().getTime() + deployWaitingTime * SECOND);
                             setTimeout(update, waitPeriod);
                         }
                     } else {

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -275,7 +275,7 @@ function waitForDeployment(application, environmentName, versionLabel, start) {
     let degraded = false;
     let healThreshold;
     let deploymentFailed = false;
-    let deployWaitingTime = ParseInt(Process.env.INPUT_MAX_WAITING_DEPLOY_TIME || 30);
+    let deployWaitingTime = parseInt(Process.env.INPUT_MAX_WAITING_DEPLOY_TIME || 30);
 
     const SECOND = 1000;
     const MINUTE = 60 * SECOND;


### PR DESCRIPTION
@einaregilsson 

If Beanstalk environment is low spec, deployment is failed sometimes, because deployment consume the machine resource.

This patch will make supporting changeable deployment timeout.

Best regards.