### PR TITLE
A way to handle region specific s3 buckets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   wait_for_environment_recovery:
     description: 'How many seconds to wait for the environment to return to Green state after deployment is finished. Default is 30 seconds.'
     required: false
+  region_specific_s3:
+    description: 'If your s3 bucket is region specific e.g. bucketname.s3.af-south-1.amazonaws.com . Default is false.'
+    required: false
 
 branding:
   icon: 'arrow-up'  


### PR DESCRIPTION
When I used the elastic beanstalk GUI it made me a region specific s3 bucket. So its like this ```bucketname.s3.af-south-1.amazonaws.com``` rather than ```bucketname.s3.amazonaws.com```. When deploying the current action failed when running the ```checkIfFileExistsInS3``` and ```uploadFileToS3``` function.

I'm not sure if this is the best way to do it. But the following works for me.
Let me know if you have ideas to improve.

Thanks for making the action.