### PR TITLE
Follow AWS redirects

### DIFF
--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -93,7 +93,16 @@ function awsApiRequest(options) {
             if (err) {
                 reject(err);
             } else {
-                resolve(result);
+                if (result.statusCode >= 300 && result.statusCode < 400 && result.headers.location) {
+                    const url = new URL(result.headers.location);
+                    headers.Host = url.hostname;
+                    resolve(awsApiRequest({
+                        ...options,
+                        host: url.hostname
+                    }));
+                } else {
+                    resolve(result);
+                }
             }
         });
     });


### PR DESCRIPTION
I've faced the same issue with 307 response code https://github.com/einaregilsson/beanstalk-deploy/issues/17

As of AWS recommendation, it works if follow the redirect, in my case, to a specific S3 location
https://aws.amazon.com/premiumsupport/knowledge-center/s3-http-307-response/