### PR TITLE
Adding 'aws_session_token' option for deploying with an assumed AWS role

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ attempt to deploy that. In the example below the action would attempt do deploy 
 
 ### Optional parameters
 
+`aws_session_token`: If you are running the action with temporary security credentials using the AWS Security Token Service API. For example, you may be assuming a role in AWS to execute the deploy through something like AWS's [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) action.
+
 `use_existing_version_if_available`: This can be set to `true` and then
 the program will deploy a version already in Elastic Beanstalk if it exists, but if it doesn't exist it will create it
 from the deployment package you specify. This can be useful when deploying to multiple environments, based on commit message.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   aws_secret_key:
     description: 'AWS Secret Key'
     required: true
+  aws_session_token:
+    description: 'AWS Session Token when using temporary security credentials such as when assuming a role in AWS through STS'
+    required: false  
   region:
     description: 'AWS Region'
     required: true

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -8,6 +8,7 @@ function awsApiRequest(options) {
             service = options.service,
             accessKey = options.accessKey || awsApiRequest.accessKey || process.env.AWS_ACCESS_KEY_ID,
             secretKey = options.secretKey || awsApiRequest.secretKey || process.env.AWS_SECRET_ACCESS_KEY,
+            sessionToken = options.sessionToken || awsApiRequest.sessionToken || process.env.AWS_SESSION_TOKEN,
             method = options.method || 'GET',
             path = options.path || '/',
             querystring = options.querystring || {},
@@ -72,13 +73,15 @@ function awsApiRequest(options) {
         let timestamp = new Date().toISOString().replace(/(-|:|\.\d\d\d)/g, ''); // YYYYMMDD'T'HHmmSS'Z'
         let datestamp = timestamp.substr(0,8);
 
+        let sessionTokenHeader = sessionToken ? {'x-amz-security-token': sessionToken} : {};
+
         let reqHeaders = Object.assign({
             Accept : 'application/json',
             Host : host,
             'Content-Type' : 'application/json',
             'x-amz-date' : timestamp,
             'x-amz-content-sha256' : sha256(payload)
-        }, headers); // Passed in headers override these...
+        }, sessionTokenHeader, headers); // Passed in headers override these...
 
         let canonicalRequest = createCanonicalRequest(method, path, querystring, reqHeaders, payload);
         let stringToSign = createStringToSign(timestamp, region, service, canonicalRequest);

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -245,6 +245,7 @@ function main() {
 
         awsApiRequest.accessKey = strip(process.env.INPUT_AWS_ACCESS_KEY);
         awsApiRequest.secretKey = strip(process.env.INPUT_AWS_SECRET_KEY);
+        awsApiRequest.sessionToken = strip(process.env.INPUT_AWS_SESSION_TOKEN);
         awsApiRequest.region = strip(process.env.INPUT_REGION);
 
         if ((process.env.INPUT_WAIT_FOR_DEPLOYMENT || '').toLowerCase() == 'false') {
@@ -272,6 +273,7 @@ function main() {
 
         awsApiRequest.accessKey = strip(process.env.AWS_ACCESS_KEY_ID);
         awsApiRequest.secretKey = strip(process.env.AWS_SECRET_ACCESS_KEY);
+        awsApiRequest.sessionToken = strip(process.env.AWS_SESSION_TOKEN);
         awsApiRequest.region = strip(region);
     }
 


### PR DESCRIPTION
This action works perfectly for me apart from one particular use case:

In order to run the deploy I want to assume a role using AWS's STS service and the [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) action. In order for this to work I need to provide an `AWS_SESSION_TOKEN` in the header of the request so the deploy will work with my assumed role.

Please let me know what you think.