### PR TITLE
Use GITHUB_ACTIONS environment variable to detect if running in an action

### DIFF
--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -4,7 +4,7 @@
 const awsApiRequest = require('./aws-api-request');
 const fs = require('fs');
 
-const IS_GITHUB_ACTION = !!process.env.GITHUB_ACTION;
+const IS_GITHUB_ACTION = !!process.env.GITHUB_ACTIONS;
 
 if (IS_GITHUB_ACTION) {
     console.error = msg => console.log(`::error::${msg}`);


### PR DESCRIPTION
Use GITHUB_ACTIONS environment variable for detecting GitHub Actions, as it appears they are not always setting an ID in deployment actions (we had a bunch of deploys fail and this fix resolved the issue). https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables states that GITHUB_ACTIONS will always be set, so best to just use that. 