### PR TITLE
feat(beanstalk-deploy): add an option to include or exclude application name as directory while uploading to s3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,10 @@ inputs:
   wait_for_environment_recovery:
     description: 'How many seconds to wait for the environment to return to Green state after deployment is finished. Default is 30 seconds.'
     required: false
-
+  add_app_prefix:
+    description: 'Add application prefix as folder path while uploading to S3'
+    required: false
+    
 branding:
   icon: 'arrow-up'  
   color: 'green'

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -130,10 +130,7 @@ function request(method, path, headers, querystring, data, callback) {
     delete headers.Host;
     headers['Content-Length'] = data.length;
     const port = 443;
-    console.log('qs', qs);
-    console.log('path', path);
-    console.log('hostname', hostname);
-    console.log('headers', headers);
+    
     try {
         const options = { hostname, port, path, method, headers };
         const req = https.request(options, res => {

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -135,6 +135,8 @@ function request(method, path, headers, querystring, data, callback) {
     console.log('headers', headers);
     console.log('qs', qs);
     console.log('path', path);
+    path = encodeURIComponent(path);
+    console.log('path encoded', path);
     try {
         const options = { hostname, port, path, method, headers };
         const req = https.request(options, res => {

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -130,6 +130,10 @@ function request(method, path, headers, querystring, data, callback) {
     delete headers.Host;
     headers['Content-Length'] = data.length;
     const port = 443;
+    console.log('qs', qs);
+    console.log('path', path);
+    console.log('hostname', hostname);
+    console.log('headers', headers);
     try {
         const options = { hostname, port, path, method, headers };
         const req = https.request(options, res => {

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -131,6 +131,10 @@ function request(method, path, headers, querystring, data, callback) {
     delete headers.Host;
     headers['Content-Length'] = data.length;
     const port = 443;
+    console.log('hostname', hostname);
+    console.log('headers', headers);
+    console.log('qs', qs);
+    console.log('path', path);
     try {
         const options = { hostname, port, path, method, headers };
         const req = https.request(options, res => {
@@ -160,6 +164,7 @@ function request(method, path, headers, querystring, data, callback) {
         }
         req.end();
     } catch(err) {
+        console.log('catch err', err);
         callback(err);
     }
 }

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -94,7 +94,6 @@ function awsApiRequest(options) {
         //Now, lets finally do a HTTP REQUEST!!!
         request(method, path, reqHeaders, querystring, payload, (err, result) => {
             if (err) {
-                console.log('err', err);
                 reject(err);
             } else {
                 if (result.statusCode >= 300 && result.statusCode < 400 && result.headers.location) {
@@ -131,12 +130,6 @@ function request(method, path, headers, querystring, data, callback) {
     delete headers.Host;
     headers['Content-Length'] = data.length;
     const port = 443;
-    console.log('hostname', hostname);
-    console.log('headers', headers);
-    console.log('qs', qs);
-    console.log('path', path);
-    path = encodeURIComponent(path);
-    console.log('path encoded', path);
     try {
         const options = { hostname, port, path, method, headers };
         const req = https.request(options, res => {
@@ -166,7 +159,6 @@ function request(method, path, headers, querystring, data, callback) {
         }
         req.end();
     } catch(err) {
-        console.log('catch err', err);
         callback(err);
     }
 }

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -94,6 +94,7 @@ function awsApiRequest(options) {
         //Now, lets finally do a HTTP REQUEST!!!
         request(method, path, reqHeaders, querystring, payload, (err, result) => {
             if (err) {
+                console.log('err', err);
                 reject(err);
             } else {
                 if (result.statusCode >= 300 && result.statusCode < 400 && result.headers.location) {

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -240,7 +240,7 @@ function main() {
         useExistingVersionIfAvailable, 
         waitForRecoverySeconds = 30, 
         waitUntilDeploymentIsFinished = true, //Whether or not to wait for the deployment to complete...
-        addApplicationNamePrefix = false;
+        addApplicationNamePrefix = true;
 
     if (IS_GITHUB_ACTION) { //Running in GitHub Actions
         application = strip(process.env.INPUT_APPLICATION_NAME);
@@ -258,8 +258,8 @@ function main() {
             waitUntilDeploymentIsFinished = false;
         }
         
-        if ((process.env.INPUT_ADD_APP_PREFIX || '').toLowerCase() == 'true') {
-            addApplicationNamePrefix = true;
+        if ((process.env.INPUT_ADD_APP_PREFIX || '').toLowerCase() == 'false') {
+            addApplicationNamePrefix = false;
         }
 
         if (process.env.INPUT_WAIT_FOR_ENVIRONMENT_RECOVERY) {

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -132,7 +132,7 @@ function expect(status, result, extraErrorMessage) {
 //Uploads zip file, creates new version and deploys it
 function deployNewVersion(application, environmentName, versionLabel, versionDescription, file, waitUntilDeploymentIsFinished, waitForRecoverySeconds) {
 
-    let s3Key = `/${application}/${versionLabel}.zip`;
+    let s3Key = `/${encodeURIComponent(application)}/${versionLabel}.zip`;
     let bucket, deployStart, fileBuffer;
 
     readFile(file).then(result => {


### PR DESCRIPTION
Hey,

I was facing with the exact issues with #28 and #21.

It turns out that my elasticbeanstalk bucket doesn't have a folder structure grouped by application name, so that's why the zip file cannot be uploaded. Also since there was an space in my application name, it was throwing the TypeError.

Updating the `s3Key` to include only `versionLabel.zip` fixed these errors for me.

So i added `add_app_prefix` option which defaults to `false` and and is optional. I didn't thought much about naming of it, it can be discussed.

This may fix #28 
May also fix #21 if issue owner has the same bucket type with me:

I have no idea why it can't encode application name properly, it may subject to another pull request.