### PR TITLE
fix: uploading to s3 when application name includes parentheses

### DIFF
--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -52,7 +52,10 @@ function awsApiRequest(options) {
             //Changed this from double encoding the path to single encoding it, to make S3 paths with spaces work. However, the documentation said to
             //double encode it...? The only time we actually encode a path other than / is when uploading to S3 so just change this to single encoding here
             //but it's possible it will mess up if the path has some weird characters that should be double encoded maybe??? If you had weird symbols in your version number?
-            canonical += encodeURI(path) + '\n';
+            //
+            //Unencoded parentheses in the path is valid. However, they must be encoded in the canonical path to pass signature verification even if
+            //the actual path has them unencoded.
+            canonical += encodeURI(path).replace(/\(/g, '%28').replace(/\)/g, '%29') + '\n';
         
             let qsKeys = Object.keys(querystring);
             qsKeys.sort();


### PR DESCRIPTION
Encountered this attempting to deploy an application with parentheses in the name. The PUT request for the bundle to the S3 bucket would fail with a signature mismatch. The target path and subsequently the HTTP path would be something like `/Product%20(Dev)/versionLabel.zip` which would fail despite being a valid S3 object name (as tested with AWS CLI). Manually URL encoding the parentheses in the canonical path _without_ encoding them in the actual path caused the request to work correctly.

I have no idea if this will negatively impact other cases with simpler application names or with different options enabled.