### PR TITLE
Added optional "existing_bucket_name" parameter for using an existing bucket to deploy to. This also prevents the action from creating a storage location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       run: zip -r deploy.zip . -x '*.git*'
 
     - name: Deploy to EB
-      uses: einaregilsson/beanstalk-deploy@v16
+      uses: einaregilsson/beanstalk-deploy@v18
       with:
         aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -48,7 +48,7 @@ attempt to deploy that. In the example below the action would attempt do deploy 
 
 ```yaml
     - name: Deploy to EB
-      uses: einaregilsson/beanstalk-deploy@v16
+      uses: einaregilsson/beanstalk-deploy@v18
       with:
         aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ jobs:
 ### Deploying an existing version
 
 You can also use the action to deploy an existing version. To do this simply omit the ```deployment-package``` input parameter.
-The action will then assume that the version you pass in throught ```version_label``` already exists in Beanstalk and
-attempt to deploy that. In the example below the action would attempt do deploy existing version 12345.
+The action will then assume that the version you pass in through ```version_label``` already exists in Beanstalk and
+attempt to deploy that. In the example below the action would attempt to deploy existing version 12345.
 
 ```yaml
     - name: Deploy to EB
@@ -87,7 +87,7 @@ the version but not deploy it anywhere.
 
 `existing_bucket_name` *(since v18)*: Use this to provide an existing bucket name to upload your deployment package to.
 *It will prevent the action from (re)creating a bucket during deployment as well.*
-Omit this parameter to have this action creating the bucket. The latter requires the API key used to have the applicable permissions. 
+Omit this parameter to have the action create the bucket. The latter requires the API key used to have the applicable permissions. 
 
 ### AWS Permissions
 
@@ -123,5 +123,5 @@ everywhere.
 1. The S3 upload is a simple PUT request, we don't handle chunked upload. It has worked fine for files that are a 
 few megabytes in size, if your files are much larger than that it may cause problems.
 2. The script does not roll back if a deploy fails.
-3. There is no integration with Git, like there is in the official EB cli. This script only takes a readymade zip file and
+3. There is no integration with Git, like there is in the official EB cli. This script only takes an already made zip file and
 deploys it.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ triggered the build, `version_description: ${{github.SHA}}`.
 `environment_name`: In version 10 this parameter becomes optional. If you don't pass an environment in the action will simply create
 the version but not deploy it anywhere.
 
+`existing_bucket_name` *(since v18)*: Use this to provide an existing bucket name to upload your deployment package to.
+*It will prevent the action from (re)creating a bucket during deployment as well.*
+Omit this parameter to have this action creating the bucket. The latter requires the API key used to have the applicable permissions. 
+
 ### AWS Permissions
 
 It should be enough for your AWS user to have the policies **AWSElasticBeanstalkWebTier** and **AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy** attached 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   deployment_package:
     description: 'Zip file with the version to deploy. If skipped the action will deploy existing version.'
     required: false
+  existing_bucket_name:
+    description: 'Whether the action should skip creating a new bucket and use the given one to upload the deployment package to instead. When omitted the actions will (try to) create a new one during deployment.'
+    required: false
   use_existing_version_if_available:
     description: 'If set to "true" then the action will deploy an existing version with the given version_label if it already exists, but otherwise create the version and deploy it.'
     required: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beanstalk-deploy",
-  "version": "16.0.0",
+  "version": "18.0.0",
   "description": "GitHub Action + command line tool to deploy to AWS Elastic Beanstalk.",
   "main": "beanstalk-deploy.js",
   "scripts": {


### PR DESCRIPTION
Hi! Thanks for your awesome action.

I'd like to add an optional parameter for specifying an existing bucket, allowing the action to skip creating a new storage location (or the same one when it was created before) on deploy. This allows us to limit the permissions required as well.

Let me know if you're open to such addition to your script and if so, any changes/conventions/naming you'd like to see differently in this PR.

Changes:
- Added new optional `existing_bucket_name` parameter for Actions (the command line versions remains as-is).
- Bumped version twice, as it seems that `v17` was released, but not (yet) updated in the package file.