### PR TITLE
Cli support for customizing recovery time

### DIFF
--- a/cli-recovery-time
+++ b/cli-recovery-time
@@ -301,6 +301,10 @@ function main() {
         awsApiRequest.secretKey = strip(process.env.AWS_SECRET_ACCESS_KEY);
         awsApiRequest.sessionToken = strip(process.env.AWS_SESSION_TOKEN);
         awsApiRequest.region = strip(region);
+        
+        if (process.env.WAIT_FOR_ENVIRONMENT_RECOVERY) {
+          waitForRecoverySeconds = parseInt(process.env.WAIT_FOR_ENVIRONMENT_RECOVERY);
+        }        
     }
 
     console.log('Beanstalk-Deploy: GitHub Action for deploying to Elastic Beanstalk.');


### PR DESCRIPTION
# Description
This PR brings the CLI tooling at parity with the Github Action regarding the `WAIT_FOR_ENVIRONMENT_RECOVERY` timeout that checks for environment health.

This repo has significant restrictions on being able to push branches so I had to fork and commit from the Github UI - @einaregilsson any thoughts there?

I would also like to update the README (L105-118) to:
```md
### Required environment variables:

`AWS_ACCESS_KEY_ID`

`AWS_SECRET_ACCESS_KEY`

### Optional environment variables:

`WAIT_FOR_ENVIRONMENT_RECOVERY`: Same as `wait_for_environment_recovery` parameter passed to the Github Action. Manually set timeout interval between environment health checks.


Pass the rest of the parameters in on the command line, like so:
```