### PR TITLE
Use node 16 -- GH actions has deprecated 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Beanstalk Deploy'
 description: 'Deploy a zip file to AWS Elastic Beanstalk'
 author: 'Einar Egilsson'
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'beanstalk-deploy.js'
 inputs:
   aws_access_key:

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Beanstalk Deploy'
 description: 'Deploy a zip file to AWS Elastic Beanstalk'
 author: 'Einar Egilsson'
 runs:
-  using: 'node14'
+  using: 'node16'
   main: 'beanstalk-deploy.js'
 inputs:
   aws_access_key:


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/