### PR TITLE
Add useful error message if the env is missing from describeEnvironments

### DIFF
--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -426,6 +426,12 @@ function waitForDeployment(application, environmentName, versionLabel, start, wa
 
                 expect(200, result, `Failed in call to describeEnvironments`);
                 counter++;
+
+                if (result.data.DescribeEnvironmentsResponse.DescribeEnvironmentsResult.Environments !== 1) {
+                    console.error(`Deployment failed: Environment ${environmentName} was not returned by DescribeEnvironments. Does the access key have permissions to see this environment?`);
+                    process.exit(2);
+                }
+
                 let env = result.data.DescribeEnvironmentsResponse.DescribeEnvironmentsResult.Environments[0];
                 if (env.VersionLabel === versionLabel && env.Status === 'Ready') {
                     if (!degraded) {


### PR DESCRIPTION
I spent a while chasing my tail trying to find the cause of this error message:

> Deployment failed: TypeError: Cannot read property 'VersionLabel' of undefined

Turns out my IAM user did not have permission to DescribeEnvironments on my environment.

This PR adds a more helpful error message in that case.