### PR TITLE
Support other env vars in CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ The program is available as an [NPM Package](https://www.npmjs.com/package/beans
 ```npm install -g beanstalk-deploy``` and then you'll have the ```beanstalk-deploy``` command (without .js) available
 everywhere.
 
+Some additional environment variables are available to use functionality available in the GitHub Actions version:
+
+```.bash
+export INPUT_EXISTING_BUCKET_NAME=elasticbeanstalk-us-east-1-xxxxxxxxxxxx
+export INPUT_WAIT_FOR_DEPLOYMENT=false
+export INPUT_WAIT_FOR_ENVIRONMENT_RECOVERY=20 # Wait for 30 seconds for enironment recovery
+```
+
 ## Caveats
 
 1. The S3 upload is a simple PUT request, we don't handle chunked upload. It has worked fine for files that are a

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -258,6 +258,18 @@ function main() {
         waitForRecoverySeconds = 30,
         waitUntilDeploymentIsFinished = true; //Whether or not to wait for the deployment to complete...
 
+    if (process.env.INPUT_EXISTING_BUCKET_NAME) {
+        existingBucketName = strip(process.env.INPUT_EXISTING_BUCKET_NAME);
+    }
+
+    if ((process.env.INPUT_WAIT_FOR_DEPLOYMENT || '').toLowerCase() == 'false') {
+        waitUntilDeploymentIsFinished = false;
+    }
+
+    if (process.env.INPUT_WAIT_FOR_ENVIRONMENT_RECOVERY) {
+        waitForRecoverySeconds = parseInt(process.env.INPUT_WAIT_FOR_ENVIRONMENT_RECOVERY);
+    }
+
     if (IS_GITHUB_ACTION) { //Running in GitHub Actions
         application = strip(process.env.INPUT_APPLICATION_NAME);
         environmentName = strip(process.env.INPUT_ENVIRONMENT_NAME);
@@ -271,17 +283,6 @@ function main() {
         awsApiRequest.sessionToken = strip(process.env.INPUT_AWS_SESSION_TOKEN);
         awsApiRequest.region = strip(process.env.INPUT_REGION);
 
-        if (process.env.INPUT_EXISTING_BUCKET_NAME) {
-            existingBucketName = strip(process.env.INPUT_EXISTING_BUCKET_NAME);
-        }
-
-        if ((process.env.INPUT_WAIT_FOR_DEPLOYMENT || '').toLowerCase() == 'false') {
-            waitUntilDeploymentIsFinished = false;
-        }
-
-        if (process.env.INPUT_WAIT_FOR_ENVIRONMENT_RECOVERY) {
-            waitForRecoverySeconds = parseInt(process.env.INPUT_WAIT_FOR_ENVIRONMENT_RECOVERY);
-        }
         useExistingVersionIfAvailable = process.env.INPUT_USE_EXISTING_VERSION_IF_AVAILABLE == 'true' || process.env.INPUT_USE_EXISTING_VERSION_IF_AVAILABLE == 'True';
 
     } else { //Running as command line script


### PR DESCRIPTION
While locally debugging another issue, I realized I couldn't define the existing bucket name and was hitting an AWS perms error. This functionality already exists, so I moved it outside the GitHub Action conditional so it can run everywhere and added some documentation to the README.