### PR TITLE
Upgrade to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Beanstalk Deploy'
 description: 'Deploy a zip file to AWS Elastic Beanstalk'
 author: 'Einar Egilsson'
 runs:
-  using: 'node16'
+  using: 'node18'
   main: 'beanstalk-deploy.js'
 inputs:
   aws_access_key:

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Beanstalk Deploy'
 description: 'Deploy a zip file to AWS Elastic Beanstalk'
 author: 'Einar Egilsson'
 runs:
-  using: 'node18'
+  using: 'node20'
   main: 'beanstalk-deploy.js'
 inputs:
   aws_access_key:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beanstalk-deploy",
-  "version": "20.0.0",
+  "version": "22.0.0",
   "description": "GitHub Action + command line tool to deploy to AWS Elastic Beanstalk.",
   "main": "beanstalk-deploy.js",
   "scripts": {


### PR DESCRIPTION
Node 16 is no longer the LTS, and out of support.

Node 18 is the new LTS release.

This is needed for any next 14+ project, as they have dropped support for v16