### PR TITLE
feat: Switch to node24

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Generate deployment package
       run: zip -r deploy.zip . -x '*.git*'

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Beanstalk Deploy'
 description: 'Deploy a zip file to AWS Elastic Beanstalk'
 author: 'Einar Egilsson'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'beanstalk-deploy.js'
 inputs:
   aws_access_key:


### PR DESCRIPTION
GitHub Actions will remove node20 support in September of this year.

I've tested it on my professional project and everyone is working as expected without any warning left.

I've updated the checkout version to be compatible with node24 too (for the people copy/pasting).

Displayed warning when running the current `@v22` version:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v2, einaregilsson/beanstalk-deploy@v22. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```